### PR TITLE
fix: Update user model field names to match API response

### DIFF
--- a/src/lib/actions/user.js
+++ b/src/lib/actions/user.js
@@ -17,8 +17,8 @@ export const createOrUpdateUser = async (
       { clerkId: id },
       {
         $set: {
-          firstName: first_name,
-          lastName: last_name,
+          first_name: first_name,
+          last_name: last_name,
           avatar: image_url,
           email: email_addresses[0].email,
           username: username

--- a/src/lib/models/user.model.js
+++ b/src/lib/models/user.model.js
@@ -2,36 +2,18 @@ import mongoose from 'mongoose'
 
 const userSchema = new mongoose.Schema(
   {
-    clerkId: {
-      type: String,
-      required: true,
-      unique: true
-    },
-    email: {
-      type: String,
-      required: true
-    },
-    firstName: {
-      type: String,
-      required: true
-    },
-    lastName: {
-      type: String,
-      required: true
-    },
-    username: {
-      type: String,
-      required: true,
-      unique: true
-    },
-    avatar: {
-      type: String,
-      required: true
-    }
+    clerkId: { type: String, required: true, unique: true },
+    first_name: { type: String },
+    last_name: { type: String },
+    avatar: { type: String },
+    email: { type: String },
+    username: { type: String, unique: true }
+    // Add other fields here as per your Prisma schema
   },
-  { timestamps: true }
+  {
+    collection: 'User' // Ensures this schema uses the "User" collection
+  }
 )
 
-const User = mongoose.models.User || mongoose.model('User', userSchema)
-
+const User = mongoose.model('User', userSchema)
 export default User


### PR DESCRIPTION
Trying to fix mongo fetch projects error.
The user model field names have been updated to match the field names in the API response. This change ensures consistency and improves data handling.